### PR TITLE
fix: making a copy list of componentsBuffer

### DIFF
--- a/Assets/uPools/Runtime/Internal/PoolCallbackHelper.cs
+++ b/Assets/uPools/Runtime/Internal/PoolCallbackHelper.cs
@@ -10,7 +10,9 @@ namespace uPools
         public static void InvokeOnRent(GameObject obj)
         {
             obj.GetComponentsInChildren(componentsBuffer);
-            foreach (var receiver in componentsBuffer)
+            var componentsToInvoke = new List<IPoolCallbackReceiver>(componentsBuffer);
+
+            foreach (var receiver in componentsToInvoke)
             {
                 receiver.OnRent();
             }
@@ -19,10 +21,11 @@ namespace uPools
         public static void InvokeOnReturn(GameObject obj)
         {
             obj.GetComponentsInChildren(componentsBuffer);
-            foreach (var receiver in componentsBuffer)
+            var componentsToInvoke = new List<IPoolCallbackReceiver>(componentsBuffer);
+
+            foreach (var receiver in componentsToInvoke)
             {
                 receiver.OnReturn();
             }
         }
-    }
 }

--- a/Assets/uPools/Runtime/Internal/PoolCallbackHelper.cs
+++ b/Assets/uPools/Runtime/Internal/PoolCallbackHelper.cs
@@ -28,4 +28,5 @@ namespace uPools
                 receiver.OnReturn();
             }
         }
+    }
 }


### PR DESCRIPTION
Rent and Return callback raises InvalidOperationException when a pooled object triggers a new rent or return operation within the callback, causing the componentsBuffer to be altered while it is still being enumerated.